### PR TITLE
Create GitHub Workflow templates for onboarding the Issue-Labeler

### DIFF
--- a/workflow-templates/labeler-cache-retention.properties.json
+++ b/workflow-templates/labeler-cache-retention.properties.json
@@ -1,0 +1,6 @@
+{
+    "name": "Labeler: Cache Retention",
+    "description": "Regularly restore the prediction models from cache to prevent cache eviction.",
+    "iconName": "octicon tag",
+    "categories": ["utilities"]
+}

--- a/workflow-templates/labeler-cache-retention.yml
+++ b/workflow-templates/labeler-cache-retention.yml
@@ -1,0 +1,35 @@
+# Regularly restore the prediction models from cache to prevent cache eviction
+name: "Labeler: Cache Retention"
+
+# For more information about GitHub's action cache limits and eviction policy, see:
+# https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
+
+on:
+  schedule:
+    - cron: "42 18 * * *" # 18:42 every day (arbitrary time daily)
+
+  workflow_dispatch:
+    inputs:
+      cache_key:
+        description: "The cache key suffix to use for restoring the model from cache. Defaults to 'ACTIVE'."
+        required: true
+        default: "ACTIVE"
+
+env:
+  CACHE_KEY: ${{ inputs.cache_key || 'ACTIVE' }}
+
+jobs:
+  restore-cache:
+    # Do not automatically run the workflow on forks outside the 'dotnet' org
+    if: ${{ github.event_name == 'workflow_dispatch' || github.repository_owner == 'dotnet' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        type: ["issues", "pulls"]
+    steps:
+      - uses: dotnet/issue-labeler/restore@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0
+        with:
+          type: ${{ matrix.type }}
+          cache_key: ${{ env.CACHE_KEY }}
+          fail-on-cache-miss: true

--- a/workflow-templates/labeler-cache-retention.yml
+++ b/workflow-templates/labeler-cache-retention.yml
@@ -1,3 +1,6 @@
+# Workflow template imported from:
+# https://github.com/dotnet/.github/workflow-templates
+#
 # Regularly restore the prediction models from cache to prevent cache eviction
 name: "Labeler: Cache Retention"
 

--- a/workflow-templates/labeler-predict-issues.properties.json
+++ b/workflow-templates/labeler-predict-issues.properties.json
@@ -1,0 +1,6 @@
+{
+    "name": "Labeler: Predict (Issues)",
+    "description": "Predict labels for Issues using a trained model.",
+    "iconName": "octicon tag",
+    "categories": ["utilities"]
+}

--- a/workflow-templates/labeler-predict-issues.yml
+++ b/workflow-templates/labeler-predict-issues.yml
@@ -1,0 +1,57 @@
+# Predict labels for Issues using a trained model
+name: "Labeler: Predict (Issues)"
+
+on:
+  # Only automatically predict area labels when issues are first opened
+  issues:
+    types: opened
+
+  # Allow dispatching the workflow via the Actions UI, specifying ranges of numbers
+  workflow_dispatch:
+    inputs:
+      issues:
+        description: "Issue Numbers (comma-separated list of ranges)."
+        required: true
+      cache_key:
+        description: "The cache key suffix to use for restoring the model. Defaults to 'ACTIVE'."
+        required: true
+        default: "ACTIVE"
+
+env:
+  # Do not allow failure for jobs triggered automatically (as this causes red noise on the workflows list)
+  ALLOW_FAILURE: ${{ github.event_name == 'workflow_dispatch' }}
+
+  LABEL_PREFIX: "area-"
+  THRESHOLD: 0.40
+  DEFAULT_LABEL: "needs-area-label"
+  EXCLUDED_AUTHORS: "" # Comma-separated list of authors to exclude from training data
+
+jobs:
+  predict-issue-label:
+    # Do not automatically run the workflow on forks outside the 'dotnet' org
+    if: ${{ github.event_name == 'workflow_dispatch' || github.repository_owner == 'dotnet' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: "Restore issues model from cache"
+        id: restore-model
+        uses: dotnet/issue-labeler/restore@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0
+        with:
+          type: issues
+          fail-on-cache-miss: ${{ env.ALLOW_FAILURE }}
+          quiet: true
+
+      - name: "Predict issue labels"
+        id: prediction
+        if: ${{ steps.restore-model.outputs.cache-hit == 'true' }}
+        uses: dotnet/issue-labeler/predict@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0
+        with:
+          issues: ${{ inputs.issues || github.event.issue.number }}
+          label_prefix: ${{ env.LABEL_PREFIX }}
+          threshold: ${{ env.THRESHOLD }}
+          default_label: ${{ env.DEFAULT_LABEL }}
+          excluded_authors: ${{ env.EXCLUDED_AUTHORS }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        continue-on-error: ${{ !env.ALLOW_FAILURE }}

--- a/workflow-templates/labeler-predict-issues.yml
+++ b/workflow-templates/labeler-predict-issues.yml
@@ -1,3 +1,6 @@
+# Workflow template imported from:
+# https://github.com/dotnet/.github/workflow-templates
+#
 # Predict labels for Issues using a trained model
 name: "Labeler: Predict (Issues)"
 

--- a/workflow-templates/labeler-predict-pulls.properties.json
+++ b/workflow-templates/labeler-predict-pulls.properties.json
@@ -1,0 +1,6 @@
+{
+    "name": "Labeler: Predict (Pulls)",
+    "description": "Predict labels for Pull Requests using a trained model.",
+    "iconName": "octicon tag",
+    "categories": ["utilities"]
+}

--- a/workflow-templates/labeler-predict-pulls.yml
+++ b/workflow-templates/labeler-predict-pulls.yml
@@ -1,0 +1,70 @@
+# Predict labels for Pull Requests using a trained model
+name: "Labeler: Predict (Pulls)"
+
+on:
+  # Per to the following documentation:
+  # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target
+  #
+  # The `pull_request_target` event runs in the context of the base of the pull request, rather
+  # than in the context of the merge commit, as the `pull_request` event does. This prevents
+  # execution of unsafe code from the head of the pull request that could alter the repository
+  # or steal any secrets you use in your workflow. This event allows your workflow to do things
+  # like label or comment on pull requests from forks.
+  #
+  # Only automatically predict area labels when pull requests are first opened
+  pull_request_target:
+    types: opened
+
+    # Configure the branches that need to have PRs labeled
+    branches:
+      - main
+
+  # Allow dispatching the workflow via the Actions UI, specifying ranges of numbers
+  workflow_dispatch:
+    inputs:
+      pulls:
+        description: "Pull Request Numbers (comma-separated list of ranges)."
+        required: true
+      cache_key:
+        description: "The cache key suffix to use for restoring the model. Defaults to 'ACTIVE'."
+        required: true
+        default: "ACTIVE"
+
+env:
+  # Do not allow failure for jobs triggered automatically (this can block PR merge)
+  ALLOW_FAILURE: ${{ github.event_name == 'workflow_dispatch' }}
+
+  LABEL_PREFIX: "area-"
+  THRESHOLD: 0.40
+  DEFAULT_LABEL: "needs-area-label"
+  EXCLUDED_AUTHORS: "" # Comma-separated list of authors to exclude from training data
+
+jobs:
+  predict-pull-label:
+    # Do not automatically run the workflow on forks outside the 'dotnet' org
+    if: ${{ github.event_name == 'workflow_dispatch' || github.repository_owner == 'dotnet' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: "Restore pulls model from cache"
+        id: restore-model
+        uses: dotnet/issue-labeler/restore@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0
+        with:
+          type: pulls
+          fail-on-cache-miss: ${{ env.ALLOW_FAILURE }}
+          quiet: true
+
+      - name: "Predict pull labels"
+        id: prediction
+        if: ${{ steps.restore-model.outputs.cache-hit == 'true' }}
+        uses: dotnet/issue-labeler/predict@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0
+        with:
+          pulls: ${{ inputs.pulls || github.event.number }}
+          label_prefix: ${{ env.LABEL_PREFIX }}
+          threshold: ${{ env.THRESHOLD }}
+          default_label: ${{ env.DEFAULT_LABEL }}
+          excluded_authors: ${{ env.EXCLUDED_AUTHORS }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        continue-on-error: ${{ !env.ALLOW_FAILURE }}

--- a/workflow-templates/labeler-predict-pulls.yml
+++ b/workflow-templates/labeler-predict-pulls.yml
@@ -1,3 +1,6 @@
+# Workflow template imported from:
+# https://github.com/dotnet/.github/workflow-templates
+#
 # Predict labels for Pull Requests using a trained model
 name: "Labeler: Predict (Pulls)"
 

--- a/workflow-templates/labeler-promote.properties.json
+++ b/workflow-templates/labeler-promote.properties.json
@@ -1,0 +1,6 @@
+{
+    "name": "Labeler: Promotion",
+    "description": "Promote a model from staging to 'ACTIVE', backing up the currently 'ACTIVE' model.",
+    "iconName": "octicon tag",
+    "categories": ["utilities"]
+}

--- a/workflow-templates/labeler-promote.yml
+++ b/workflow-templates/labeler-promote.yml
@@ -1,0 +1,49 @@
+# Promote a model from staging to 'ACTIVE', backing up the currently 'ACTIVE' model
+name: "Labeler: Promotion"
+
+on:
+  # Dispatched via the Actions UI, promotes the staged models from
+  # a staged slot into the prediction environment
+  workflow_dispatch:
+    inputs:
+      issues:
+        description: "Issues: Promote Model"
+        type: boolean
+        required: true
+      pulls:
+        description: "Pulls: Promote Model"
+        type: boolean
+        required: true
+      staged_key:
+        description: "The cache key suffix to use for promoting a staged model to 'ACTIVE'. Defaults to 'staged'."
+        required: true
+        default: "staged"
+      backup_key:
+        description: "The cache key suffix to use for backing up the currently active model. Defaults to 'backup'."
+        default: "backup"
+
+permissions:
+  actions: write
+
+jobs:
+  promote-issues:
+    if: ${{ inputs.issues }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Promote Model for Issues"
+        uses: dotnet/issue-labeler/promote@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0
+        with:
+          type: "issues"
+          staged_key: ${{ inputs.staged_key }}
+          backup_key: ${{ inputs.backup_key }}
+
+  promote-pulls:
+    if: ${{ inputs.pulls }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Promote Model for Pull Requests"
+        uses: dotnet/issue-labeler/promote@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0
+        with:
+          type: "pulls"
+          staged_key: ${{ inputs.staged_key }}
+          backup_key: ${{ inputs.backup_key }}

--- a/workflow-templates/labeler-promote.yml
+++ b/workflow-templates/labeler-promote.yml
@@ -1,3 +1,6 @@
+# Workflow template imported from:
+# https://github.com/dotnet/.github/workflow-templates
+#
 # Promote a model from staging to 'ACTIVE', backing up the currently 'ACTIVE' model
 name: "Labeler: Promotion"
 

--- a/workflow-templates/labeler-train.properties.json
+++ b/workflow-templates/labeler-train.properties.json
@@ -1,0 +1,6 @@
+{
+    "name": "Labeler: Training",
+    "description": "Train the Issues and Pull Requests models for label prediction.",
+    "iconName": "octicon tag",
+    "categories": ["utilities"]
+}

--- a/workflow-templates/labeler-train.yml
+++ b/workflow-templates/labeler-train.yml
@@ -1,0 +1,163 @@
+# Train the Issues and Pull Requests models for label prediction
+name: "Labeler: Training"
+
+on:
+  workflow_dispatch:
+    inputs:
+      type:
+        description: "Issues or Pull Requests"
+        type: choice
+        required: true
+        default: "Both"
+        options:
+          - "Both"
+          - "Issues"
+          - "Pull Requests"
+
+      steps:
+        description: "Training Steps"
+        type: choice
+        required: true
+        default: "All"
+        options:
+          - "All"
+          - "Download Data"
+          - "Train Model"
+          - "Test Model"
+
+      repository:
+        description: "The org/repo to download data from. Defaults to the current repository."
+      limit:
+        description: "Max number of items to download for training/testing the model (newest items are used). Defaults to the max number of pages times the page size."
+        type: number
+      page_size:
+        description: "Number of items per page in GitHub API requests. Defaults to 100 for issues, 25 for pull requests."
+        type: number
+      page_limit:
+        description: "Maximum number of pages to download for training/testing the model. Defaults to 1000 for issues, 4000 for pull requests."
+        type: number
+      cache_key_suffix:
+        description: "The cache key suffix to use for staged data/models (use 'ACTIVE' to bypass staging). Defaults to 'staged'."
+        required: true
+        default: "staged"
+
+env:
+  CACHE_KEY: ${{ inputs.cache_key_suffix }}
+  REPOSITORY: ${{ inputs.repository || github.repository }}
+  LABEL_PREFIX: "area-"
+  THRESHOLD: "0.40"
+  LIMIT: ${{ inputs.limit }}
+  PAGE_SIZE: ${{ inputs.page_size }}
+  PAGE_LIMIT: ${{ inputs.page_limit }}
+  EXCLUDED_AUTHORS: "" # Comma-separated list of authors to exclude from training data
+
+jobs:
+  download-issues:
+    if: ${{ contains(fromJSON('["Both", "Issues"]'), inputs.type) && contains(fromJSON('["All", "Download Data"]'), inputs.steps) }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+    steps:
+      - name: "Download Issues"
+        uses: dotnet/issue-labeler/download@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0
+        with:
+          type: "issues"
+          cache_key: ${{ env.CACHE_KEY }}
+          repository: ${{ env.REPOSITORY }}
+          label_prefix: ${{ env.LABEL_PREFIX }}
+          limit: ${{ env.LIMIT }}
+          page_size: ${{ env.PAGE_SIZE }}
+          page_limit: ${{ env.PAGE_LIMIT }}
+          excluded_authors: ${{ env.EXCLUDED_AUTHORS }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+  download-pulls:
+    if: ${{ contains(fromJSON('["Both", "Pull Requests"]'), inputs.type) && contains(fromJSON('["All", "Download Data"]'), inputs.steps) }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: "Download Pull Requests"
+        uses: dotnet/issue-labeler/download@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0
+        with:
+          type: "pulls"
+          cache_key: ${{ env.CACHE_KEY }}
+          repository: ${{ env.REPOSITORY }}
+          label_prefix: ${{ env.LABEL_PREFIX }}
+          limit: ${{ env.LIMIT }}
+          page_size: ${{ env.PAGE_SIZE }}
+          page_limit: ${{ env.PAGE_LIMIT }}
+          excluded_authors: ${{ env.EXCLUDED_AUTHORS }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+  train-issues:
+    if: ${{ always() && contains(fromJSON('["Both", "Issues"]'), inputs.type) && contains(fromJSON('["All", "Train Model"]'), inputs.steps) && contains(fromJSON('["success", "skipped"]'), needs.download-issues.result) }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    needs: download-issues
+    steps:
+      - name: "Train Model for Issues"
+        uses: dotnet/issue-labeler/train@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0
+        with:
+          type: "issues"
+          data_cache_key: ${{ env.CACHE_KEY }}
+          model_cache_key: ${{ env.CACHE_KEY }}
+
+  train-pulls:
+    if: ${{ always() && contains(fromJSON('["Both", "Pull Requests"]'), inputs.type) && contains(fromJSON('["All", "Train Model"]'), inputs.steps) && contains(fromJSON('["success", "skipped"]'), needs.download-pulls.result) }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    needs: download-pulls
+    steps:
+      - name: "Train Model for Pull Requests"
+        uses: dotnet/issue-labeler/train@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0
+        with:
+          type: "pulls"
+          data_cache_key: ${{ env.CACHE_KEY }}
+          model_cache_key: ${{ env.CACHE_KEY }}
+
+  test-issues:
+    if: ${{ always() && contains(fromJSON('["Both", "Issues"]'), inputs.type) && contains(fromJSON('["All", "Test Model"]'), inputs.steps) && contains(fromJSON('["success", "skipped"]'), needs.train-issues.result) }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+    needs: train-issues
+    steps:
+      - name: "Test Model for Issues"
+        uses: dotnet/issue-labeler/test@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0
+        with:
+          type: "issues"
+          cache_key: ${{ env.CACHE_KEY }}
+          repository: ${{ env.REPOSITORY }}
+          label_prefix: ${{ env.LABEL_PREFIX }}
+          threshold: ${{ env.THRESHOLD }}
+          limit: ${{ env.LIMIT }}
+          page_size: ${{ env.PAGE_SIZE }}
+          page_limit: ${{ env.PAGE_LIMIT }}
+          excluded_authors: ${{ env.EXCLUDED_AUTHORS }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+  test-pulls:
+    if: ${{ always() && contains(fromJSON('["Both", "Pull Requests"]'), inputs.type) && contains(fromJSON('["All", "Test Model"]'), inputs.steps) && contains(fromJSON('["success", "skipped"]'), needs.train-pulls.result) }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    needs: train-pulls
+    steps:
+      - name: "Test Model for Pull Requests"
+        uses: dotnet/issue-labeler/test@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0
+        with:
+          type: "pulls"
+          cache_key: ${{ env.CACHE_KEY }}
+          repository: ${{ env.REPOSITORY }}
+          label_prefix: ${{ env.LABEL_PREFIX }}
+          threshold: ${{ env.THRESHOLD }}
+          limit: ${{ env.LIMIT }}
+          page_size: ${{ env.PAGE_SIZE }}
+          page_limit: ${{ env.PAGE_LIMIT }}
+          excluded_authors: ${{ env.EXCLUDED_AUTHORS }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/workflow-templates/labeler-train.yml
+++ b/workflow-templates/labeler-train.yml
@@ -1,3 +1,6 @@
+# Workflow template imported from:
+# https://github.com/dotnet/.github/workflow-templates
+#
 # Train the Issues and Pull Requests models for label prediction
 name: "Labeler: Training"
 


### PR DESCRIPTION
By adding these workflow templates, the GitHub Actions UI shows these worfklow templates and provides an experience for installing the workflows into any repository in the dotnet org. These templates would then serve as the source of truth for the default templates.